### PR TITLE
Fix typo in site title

### DIFF
--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -9,7 +9,7 @@
   const STRINGS = {
     site_title: {
       en: "GC Notify System Status",
-      fr: "État du système GC Notify",
+      fr: "État du système Notification GC",
     },
     lang_button: {
       en: "Français",


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the site's name in FR from "GC Notify" to "Notification GC"

# Test instructions | Instructions pour tester la modification

1. The site title in FR should be "État du système Notification GC"
