### PR TITLE
Typography improvements for GCA content

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -10,12 +10,21 @@ a {
 }
 
 p {
-  @apply max-w-[80ch]
+  @apply max-w-[70ch] mt-4 leading-relaxed;
 }
 
 hr {
-  @apply my-gutter
+  @apply my-gutterAndAHalf border-solid border-t border-gray-300
 }
+
+h1, h2, h3 {
+  text-wrap: balance;
+}
+
+p+h3 {
+  @apply border-t border-gray-300 pt-gutterHalf
+}
+
 
 /**
  * Layout components

--- a/src/js/articles.js
+++ b/src/js/articles.js
@@ -31,7 +31,7 @@
     // fix up h3's to use tailwind
     incident_html = incident_html.replace(
       /wp-block-heading/g,
-      "text-3xl text-gray-800 dark:text-gray-400 font-[425] font-heading leading-none mb-3 mt-10",
+      "text-3xl font-[425] font-heading leading-tight mt-gutterAndAHalf",
     );
 
     // remove h2


### PR DESCRIPTION
# Summary | Résumé

- Tweaking the tailwind utilities applied to headings so it is a bit more readable
- Enhance with `text-wrap: balance` Shoudl work in recent browsers and simply enhances how heading lines are composed. For example, preventing single words wrapping.
- Add some basic styles for paragraphs
- Add a border between updates, this assumes each update ends with a P and is separated by a H3

# Test instructions | Instructions pour tester la modification

- Review the status page