### PR TITLE
Removed tab index zero

### DIFF
--- a/src/js/component_status.js
+++ b/src/js/component_status.js
@@ -49,7 +49,7 @@
     },
   };
   const COMPONENT_HTML = ({ component_id, component_status }) => `
-    <li class="flex items-start p-4 gap-2 bg-white dark:bg-black border-b-8 ${component_status.border}" tabindex="0" id="${component_id}">
+  <li class="flex items-start p-4 gap-2 bg-white dark:bg-black border-b-8 ${component_status.border}" id="${component_id}">
     <i class="text-3xl ${COMPONENTS[component_id].icon}"></i>
       <div class="flex flex-col sm:flex-row md:flex-col lg:flex-row gap-2 items-baseline justify-between w-full py-1">
         <span data-i18n="${component_id}"></span>


### PR DESCRIPTION
# Summary | Résumé

Components: GC Notify API – GC Notify Website – Email sending – Text message sending.
Observation:
The

element is marked with tabindex="0", making it focusable by keyboard users. However, the element does not contain any interactive role or behavior (e.g., it is not a link, button, or control). This creates confusion for users who rely on keyboard navigation or screen readers, as the purpose of the focusable item is unclear.
This violates accessibility best practices, as keyboard-focusable elements are expected to provide an interactive function or clearly communicate their role.

(Attachment:
7.19.3. Non-Interactive Element Made Focusable.png
7.19.3. Non-Interactive Element Made Focusable.mp4

Recommendation:

Remove tabindex="0"
If the element is purely visual or informative and not meant to be interactive:
Make the element fully interactive - If the intent is to allow keyboard interaction (e.g., it opens a panel, navigates, or performs an action):
Add appropriate ARIA role (e.g., role="button", role="link")
Add keyboard event handlers to support Enter and Space keys
Provide clear visual and textual cues about interactivity

# Test instructions | Instructions pour tester la modification

Removed tabindex 0

---
