### PR TITLE
Add skip to main content link, styled similarly to notification-admin

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -49,3 +49,26 @@ p + ol, p + ul {
  .action-required {
   @apply my-gutter px-gutter border-l-4 border-gray-300;
  }
+
+/**
+ * Skip to main content accessibility component
+ */
+.skiplink:focus {
+  @apply flex outline-none bg-yellow-300 border-b-2 border-blue-500 no-underline;
+  z-index: 1;
+}
+
+.skiplink:not(:focus) {
+  @apply absolute;
+  left: -9999em;
+}
+
+.skiplink:focus,
+.skiplink:visited {
+  color: #0b0c0c;
+}
+
+#skiplink-container .skiplink {
+  display: -moz-inline-stack;
+  display: inline-block;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,10 @@
   <body
     class="text-xl min-w-[320px] bg-white text-black dark:bg-black dark:text-white"
   >
+    <!-- Skip to main content link for accessibility -->
+      <div class="flex w-full justify-start md:justify-center md:col-start-2 items-center md:mx-auto" id="skiplink-container">
+          <a href="#main-content" class="skiplink px-2 py-2" data-i18n="skip_to_main_content">Skip to main content</a>
+      </div>
     <!--Nav-->
     <nav id="header" class="bg-white" aria-labelledby="site-title">
       <div
@@ -89,7 +93,7 @@
       </div>
     </header>
 
-    <main>
+    <main id="main-content">
       <div class="bg-gray-200 dark:bg-gray-800">
         <div class="container mx-auto px-gutterHalf py-doubleGutter w-full">
           <ul

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -128,6 +128,10 @@
       en: "Loading...",
       fr: "Chargement...",
     },
+    skip_to_main_content: {
+      en: "Skip to main content",
+      fr: "Passer au contenu principal",
+    },
   };
   /**
    * Switches the UI language between English and French.


### PR DESCRIPTION
# Summary | Résumé

Fix for: https://github.com/cds-snc/notification-planning/issues/2385

<img width="1153" height="840" alt="Screenshot 2025-09-09 at 4 48 42 PM" src="https://github.com/user-attachments/assets/8dfc5787-fb47-49b9-9b65-1e54aed40c15" />

# Test instructions | Instructions pour tester la modification

1. check out the branch
2. run `npm install` and `npm run dev`
3. visit the page and hit `tab` - you should see the skip link
4. it should be translated correctly if you click "french" and clicking it should focus the main content