### PR TITLE
Fix spacing issues around statuses

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -35,7 +35,7 @@ ol {
 }
 
 ul {
-  @apply list-disc pl-gutter space-y-2;
+  @apply list-disc;
 }
 
 p + ol, p + ul {


### PR DESCRIPTION
# Summary | Résumé

Fix some styling issues.
Before:
<img width="1067" height="685" alt="Screenshot 2025-09-10 at 2 59 31 PM" src="https://github.com/user-attachments/assets/e4a3dcf2-79e9-435b-953c-5e9d8b55c63c" />

After:
<img width="1042" height="467" alt="Screenshot 2025-09-10 at 2 59 12 PM" src="https://github.com/user-attachments/assets/27f3d69b-52d0-4568-9a92-e814cb0a0c50" />

# Test instructions | Instructions pour tester la modification

Check out locally and run, styling issues for status boxes should be fixed.