### PR TITLE
Make footer nav item separators unfocusable

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -35,7 +35,7 @@ ol {
 }
 
 ul {
-  @apply list-disc pl-gutter space-y-2;
+  @apply pl-gutter;
 }
 
 p + ol, p + ul {

--- a/src/index.html
+++ b/src/index.html
@@ -199,7 +199,7 @@
           <ul
             class="text-base leading-8 [&_a]:text-black [&_svg]:hidden md:[&_svg]:inline md:[&_svg]:mx-gutterHalf flex flex-col md:flex-row flex-wrap gap-gutterHalf md:gap-0 md:items-center"
           >
-            <li class="lg:list-none">
+            <li>
               <a
                 href="https://notification.canada.ca/privacy"
                 data-i18n="privacy privacy_href"
@@ -211,6 +211,8 @@
                 viewBox="0 0 4 4"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
               >
                 <circle cx="2" cy="2" r="2" fill="black" />
               </svg>
@@ -228,6 +230,8 @@
                 viewBox="0 0 4 4"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
               >
                 <circle cx="2" cy="2" r="2" fill="black" />
               </svg>
@@ -245,6 +249,8 @@
                 viewBox="0 0 4 4"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
               >
                 <circle cx="2" cy="2" r="2" fill="black" />
               </svg>
@@ -262,6 +268,8 @@
                 viewBox="0 0 4 4"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
               >
                 <circle cx="2" cy="2" r="2" fill="black" />
               </svg>


### PR DESCRIPTION
# Summary | Résumé
This PR fixes: https://github.com/cds-snc/notification-planning/issues/2384
- Remove CSS that added margin-top to all the footer nav links except for the first one, causing alignment issues
- Added `aria-hidden=true focusable=false` to the SVGs separating the footer link items

# Test instructions | Instructions pour tester la modification
1. Run this branch locally and navigate to the main page
2. Turn on VoiceOver and navigate to the footer links
3. Using your arrow keys, try to navigate to the little dot SVGs separating the footer links
4. Note that they are not selectable