### PR TITLE
Fix status padding again

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -38,6 +38,10 @@ main ul {
   @apply list-disc pl-gutter;
 }
 
+ul#component_status_list {
+  @apply pl-0;
+}
+
 p + ol, p + ul {
   @apply pt-4
 }


### PR DESCRIPTION
# Summary | Résumé

The left padding on the status boxes got messed up again. This PR fixes that.

# Test instructions | Instructions pour tester la modification

Check out locally, verify the status boxes are left aligned correctly:

<img width="857" height="814" alt="Screenshot 2025-09-11 at 3 05 26 PM" src="https://github.com/user-attachments/assets/8e92ddb1-2d1f-4da9-90d8-7dce96012088" />
