### PR TITLE
Get the articles content from a proxy in S3

### DIFF
--- a/cypress/e2e/frontend.cy.js
+++ b/cypress/e2e/frontend.cy.js
@@ -25,7 +25,7 @@ function interceptExternalRequests(fixture1, fixture2) {
   if (!fixture2) fixture2 = 'articles-en.json';
 
   cy.intercept('/response.json*', { fixture: fixture1 }).as('status_update');
-  cy.intercept('GET','https://articles.alpha.canada.ca/notification-gc-notify/wp-json/wp/v2/pages?slug=system-status&lang=en',
+  cy.intercept('GET', '/articles-*.json*',
     { fixture: fixture2 }
   ).as('articles')
   cy.visit('/');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch-css": "npx tailwindcss -i ./src/css/index.css -o ./dist/css/index.css --watch",
     "watch-html": "npx copy-and-watch --watch src/**/*.html dist/ & npx copy-and-watch --watch src/js/*.js dist/js",
     "watch-assets": "npx copy-and-watch --watch src/assets/* dist/assets",
-    "dev": "mkdir dist; echo \"{}\" >dist/serve.json & cp response.json dist & npx serve dist/ & npm run watch-css & npm run watch-html & npm run watch-assets",
+    "dev": "mkdir dist; echo \"{}\" >dist/serve.json & cp response.json dist & cp cypress/fixtures/articles-en.json dist & cp cypress/fixtures/articles-fr.json dist & npx serve dist/ & npm run watch-css & npm run watch-html & npm run watch-assets",
     "format": "npx prettier --config ./.prettierrc --ignore-path ./..prettierignore src/ --write"
   },
   "repository": {

--- a/src/index.html
+++ b/src/index.html
@@ -292,7 +292,6 @@
       </div>
     </footer>
 
-    <script type="text/javascript" src="https://ebb0eeced636.edge.captcha-sdk.awswaf.com/ebb0eeced636/jsapi.js" defer></script>
     <script src="./js/articles.js"></script>
     <!-- exposes `LoadIncidentHistory()` -->
     <script src="./js/component_status.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -292,6 +292,7 @@
       </div>
     </footer>
 
+    <script type="text/javascript" src="https://ebb0eeced636.edge.captcha-sdk.awswaf.com/ebb0eeced636/jsapi.js" defer></script>
     <script src="./js/articles.js"></script>
     <!-- exposes `LoadIncidentHistory()` -->
     <script src="./js/component_status.js"></script>

--- a/src/js/articles.js
+++ b/src/js/articles.js
@@ -24,7 +24,7 @@
     document.getElementById(contentId).innerHTML = "";
     document.getElementById(loaderId).hidden = false;
 
-    const response = await fetch(incident_history_pages[lang]);
+    const response = await AwsWafIntegration.fetch(incident_history_pages[lang]);
     const incidents = await response.json();
     incident_html = incidents[0].content.rendered;
 

--- a/src/js/articles.js
+++ b/src/js/articles.js
@@ -8,8 +8,8 @@
  */
 (async function () {
   const incident_history_pages = {
-    en: "https://articles.alpha.canada.ca/notification-gc-notify/wp-json/wp/v2/pages?slug=system-status&lang=en",
-    fr: "https://articles.alpha.canada.ca/notification-gc-notify/wp-json/wp/v2/pages?slug=etat-du-systeme&lang=fr",
+    en: "/articles-en.json",
+    fr: "/articles-fr.json",
   };
 
   /**
@@ -24,7 +24,7 @@
     document.getElementById(contentId).innerHTML = "";
     document.getElementById(loaderId).hidden = false;
 
-    const response = await AwsWafIntegration.fetch(incident_history_pages[lang]);
+    const response = await fetch(incident_history_pages[lang]);
     const incidents = await response.json();
     incident_html = incidents[0].content.rendered;
 


### PR DESCRIPTION
# Summary | Résumé

Get the articles content from a proxy in S3

* https://github.com/cds-snc/notification-planning/issues/3228

# Test instructions | Instructions pour tester la modification

When you test locally with `npm run dev` you should see the fixture data: 
<img width="1101" height="792" alt="Screenshot 2026-05-26 at 2 39 58 PM" src="https://github.com/user-attachments/assets/874f8725-21c6-4e9f-9157-a7ea62e4c588" />

